### PR TITLE
ADDED WIZARD AND WIZARD SPELLS

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/WizardComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/WizardComponent.cs
@@ -1,7 +1,7 @@
 namespace Content.Server.GameTicking.Rules.Components;
 
 /// <summary>
-/// This is used for tagging a mob as a nuke operative.
+/// This is used for tagging a mob as a wizard.
 /// </summary>
 [RegisterComponent]
 public sealed class WizardComponent : Component

--- a/Content.Server/GameTicking/Rules/Components/WizardComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/WizardComponent.cs
@@ -1,0 +1,10 @@
+namespace Content.Server.GameTicking.Rules.Components;
+
+/// <summary>
+/// This is used for tagging a mob as a nuke operative.
+/// </summary>
+[RegisterComponent]
+public sealed class WizardComponent : Component
+{
+
+}

--- a/Content.Server/GameTicking/Rules/Components/WizardSpawnerComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/WizardSpawnerComponent.cs
@@ -1,0 +1,20 @@
+namespace Content.Server.GameTicking.Rules.Components;
+
+/// <summary>
+/// This is used for tagging a spawn point as a wizard spawn point
+/// and providing loadout + name for the operative on spawn.
+/// TODO: Remove once systems can request spawns from the ghost role system directly.
+/// </summary>
+[RegisterComponent]
+[Access(typeof(WizardRuleSystem))]
+public sealed class WizardSpawnerComponent : Component
+{
+    [DataField("name")]
+    public string WizardName = "";
+
+    [DataField("rolePrototype")]
+    public string WizardRolePrototype = "";
+
+    [DataField("startingGearPrototype")]
+    public string WizardStartingGear = "";
+}

--- a/Content.Server/GameTicking/Rules/Components/WizardSpawnerComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/WizardSpawnerComponent.cs
@@ -2,7 +2,7 @@ namespace Content.Server.GameTicking.Rules.Components;
 
 /// <summary>
 /// This is used for tagging a spawn point as a wizard spawn point
-/// and providing loadout + name for the operative on spawn.
+/// and providing loadout + name for the wizard on spawn.
 /// TODO: Remove once systems can request spawns from the ghost role system directly.
 /// </summary>
 [RegisterComponent]

--- a/Content.Server/GameTicking/Rules/Configurations/WizardRuleConfiguration.cs
+++ b/Content.Server/GameTicking/Rules/Configurations/WizardRuleConfiguration.cs
@@ -46,8 +46,11 @@ public sealed class WizardRuleConfiguration : GameRuleConfiguration
     [DataField("wizardLastNames", customTypeSerializer: typeof(PrototypeIdSerializer<DatasetPrototype>))]
     public string WizardLastNames = "names_wizard_last";
 
+    //<summary>
+    //    Whether or not killing all of the wizards will immidiately end the round
+    //</summary>
     [DataField("endsRound")]
-    public bool EndsRound = true;
+    public bool EndsRound = false;
 
     [DataField("shuttleMap", customTypeSerializer: typeof(ResourcePathSerializer))]
     public ResourcePath? WizardShuttleMap = new("/Maps/Shuttles/wizard.yml");

--- a/Content.Server/GameTicking/Rules/Configurations/WizardRuleConfiguration.cs
+++ b/Content.Server/GameTicking/Rules/Configurations/WizardRuleConfiguration.cs
@@ -2,7 +2,6 @@ using Content.Server.GameTicking.Rules.Configurations;
 using Content.Shared.Dataset;
 using Content.Shared.Humanoid.Prototypes;
 using Content.Shared.Roles;
-using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;

--- a/Content.Server/GameTicking/Rules/Configurations/WizardRuleConfiguration.cs
+++ b/Content.Server/GameTicking/Rules/Configurations/WizardRuleConfiguration.cs
@@ -48,7 +48,7 @@ public sealed class WizardRuleConfiguration : GameRuleConfiguration
     public string WizardLastNames = "names_wizard_last";
 
     [DataField("endsRound")]
-    public bool EndsRound = false;
+    public bool EndsRound = true;
 
     [DataField("shuttleMap", customTypeSerializer: typeof(ResourcePathSerializer))]
     public ResourcePath? WizardShuttleMap = new("/Maps/Shuttles/wizard.yml");

--- a/Content.Server/GameTicking/Rules/Configurations/WizardRuleConfiguration.cs
+++ b/Content.Server/GameTicking/Rules/Configurations/WizardRuleConfiguration.cs
@@ -1,0 +1,55 @@
+using Content.Server.GameTicking.Rules.Configurations;
+using Content.Shared.Dataset;
+using Content.Shared.Humanoid.Prototypes;
+using Content.Shared.Roles;
+using Robust.Shared.Audio;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+using Robust.Shared.Utility;
+
+namespace Content.Server.GameTicking.Rules.Configurations;
+
+public sealed class WizardRuleConfiguration : GameRuleConfiguration
+{
+    public override string Id => "Wizard";
+
+    [DataField("minPlayers")]
+    public int MinPlayers = 15;
+
+    /// <summary>
+    ///     This INCLUDES the wizards. So a value of 3 is satisfied by 2 players & 1 wizard
+    /// </summary>
+    [DataField("playersPerWizard")]
+    public int PlayersPerWizard = 15;
+
+    [DataField("maxWizards")]
+    public int MaxWizards = 2;
+
+    [DataField("randomHumanoidSettings", customTypeSerializer: typeof(PrototypeIdSerializer<RandomHumanoidSettingsPrototype>))]
+    public string RandomHumanoidSettingsPrototype = "WizardHumanoid";
+
+    [DataField("spawnPointProto", customTypeSerializer: typeof(PrototypeIdSerializer<StartingGearPrototype>))]
+    public string SpawnPointPrototype = "SpawnPointWizard";
+
+    [DataField("ghostSpawnPointProto", customTypeSerializer: typeof(PrototypeIdSerializer<StartingGearPrototype>))]
+    public string GhostSpawnPointProto = "SpawnPointGhostWizard";
+
+    [DataField("wizardRoleProto", customTypeSerializer: typeof(PrototypeIdSerializer<StartingGearPrototype>))]
+    public string WizardRoleProto = "Wizard";
+
+    [DataField("wizardStartGearProto", customTypeSerializer: typeof(PrototypeIdSerializer<StartingGearPrototype>))]
+    public string WizardStartGearPrototype = "WizardBlueGear";
+
+    [DataField("wizardFirstNames", customTypeSerializer: typeof(PrototypeIdSerializer<DatasetPrototype>))]
+    public string WizardFirstNames = "names_wizard_first";
+
+    [DataField("wizardLastNames", customTypeSerializer: typeof(PrototypeIdSerializer<DatasetPrototype>))]
+    public string WizardLastNames = "names_wizard_last";
+
+    [DataField("endsRound")]
+    public bool EndsRound = false;
+
+    [DataField("shuttleMap", customTypeSerializer: typeof(ResourcePathSerializer))]
+    public ResourcePath? WizardShuttleMap = new("/Maps/Shuttles/wizard.yml");
+}

--- a/Content.Server/GameTicking/Rules/WizardRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/WizardRuleSystem.cs
@@ -49,7 +49,7 @@ public sealed class WizardRuleSystem : GameRuleSystem
 
     private MapId? _wizardMap;
 
-    // TODO: use components, don't just cache entity UIDs
+    // TODO: use components, don't just cache entity UIDs. Until comp.owner has a replacement this will sadly stay
     // There have been (and probably still are) bugs where these refer to deleted entities from old rounds.
     private EntityUid? _wizardShuttle;
     private EntityUid? _targetStation;
@@ -385,6 +385,7 @@ public sealed class WizardRuleSystem : GameRuleSystem
         string role;
         string gear;
 
+        //TODO: setup wizard and apprentice info in the case of multi-wizard, similar to NukeOps commander and operatives
         switch (spawnNumber)
         {
             default:
@@ -560,5 +561,10 @@ public sealed class WizardRuleSystem : GameRuleSystem
             SpawnWizardsForGhostRoles();
     }
 
-    public override void Ended() { }
+    public override void Ended()
+    {
+        _wizardMap = null;
+        _wizardShuttle = null;
+        _targetStation = null;
+    }
 }

--- a/Content.Server/GameTicking/Rules/WizardRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/WizardRuleSystem.cs
@@ -1,0 +1,564 @@
+using System.Linq;
+using Content.Server.Administration.Commands;
+using Content.Server.CharacterAppearance.Components;
+using Content.Server.Chat.Managers;
+using Content.Server.GameTicking.Rules.Components;
+using Content.Server.GameTicking.Rules.Configurations;
+using Content.Server.Ghost.Roles.Components;
+using Content.Server.Ghost.Roles.Events;
+using Content.Server.Humanoid.Systems;
+using Content.Server.Mind.Components;
+using Content.Server.NPC.Systems;
+using Content.Server.Preferences.Managers;
+using Content.Server.RoundEnd;
+using Content.Server.Spawners.Components;
+using Content.Server.Station.Components;
+using Content.Server.Station.Systems;
+using Content.Server.Traitor;
+using Content.Shared.Dataset;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Preferences;
+using Content.Shared.Roles;
+using Robust.Server.GameObjects;
+using Robust.Server.Maps;
+using Robust.Server.Player;
+using Robust.Shared.Map;
+using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared.Utility;
+
+namespace Content.Server.GameTicking.Rules;
+
+public sealed class WizardRuleSystem : GameRuleSystem
+{
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly IServerPreferencesManager _prefs = default!;
+    [Dependency] private readonly IChatManager _chatManager = default!;
+    [Dependency] private readonly IMapManager _mapManager = default!;
+    [Dependency] private readonly IPlayerManager _playerSystem = default!;
+    [Dependency] private readonly FactionSystem _faction = default!;
+    [Dependency] private readonly StationSpawningSystem _stationSpawningSystem = default!;
+    [Dependency] private readonly StationSystem _stationSystem = default!;
+    [Dependency] private readonly RoundEndSystem _roundEndSystem = default!;
+    [Dependency] private readonly GameTicker _ticker = default!;
+    [Dependency] private readonly MapLoaderSystem _map = default!;
+    [Dependency] private readonly RandomHumanoidSystem _randomHumanoid = default!;
+
+    private MapId? _wizardMap;
+
+    // TODO: use components, don't just cache entity UIDs
+    // There have been (and probably still are) bugs where these refer to deleted entities from old rounds.
+    private EntityUid? _wizardShuttle;
+    private EntityUid? _targetStation;
+
+    public override string Prototype => "Wizard";
+
+    private WizardRuleConfiguration _wizardRuleConfig = new();
+
+    private enum WinType
+    {
+        /// <summary>
+        ///     Wizards died.
+        /// </summary>
+        WizardsEliminated,
+        /// <summary>
+        ///     Neutral win. The crew escaped, but the wizards did too.
+        /// </summary>
+        Neutral,
+    }
+
+    private WinType _winType = WinType.Neutral;
+
+    private WinType RuleWinType
+    {
+        get => _winType;
+        set
+        {
+            _winType = value;
+
+            if (value == WinType.WizardsEliminated)
+            {
+                _roundEndSystem.EndRound();
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Cached starting gear prototypes.
+    /// </summary>
+    private readonly Dictionary<string, StartingGearPrototype> _startingGearPrototypes = new ();
+
+    /// <summary>
+    ///     Cached wizard name prototypes.
+    /// </summary>
+    private readonly Dictionary<string, List<string>> _wizardNames = new();
+
+    /// <summary>
+    ///     Data to be used in <see cref="OnMindAdded"/> for a wizard once the Mind has been added.
+    /// </summary>
+    private readonly Dictionary<EntityUid, string> _wizardMindPendingData = new();
+
+    /// <summary>
+    ///     Players who played as a wizard at some point in the round.
+    ///     Stores the session as well as the entity name
+    /// </summary>
+    private readonly Dictionary<string, IPlayerSession> _wizardPlayers = new();
+
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<RoundStartAttemptEvent>(OnStartAttempt);
+        SubscribeLocalEvent<RulePlayerSpawningEvent>(OnPlayersSpawning);
+        SubscribeLocalEvent<WizardComponent, MobStateChangedEvent>(OnMobStateChanged);
+        SubscribeLocalEvent<RoundEndTextAppendEvent>(OnRoundEndText);
+        SubscribeLocalEvent<GameRunLevelChangedEvent>(OnRunLevelChanged);
+        SubscribeLocalEvent<WizardComponent, GhostRoleSpawnerUsedEvent>(OnPlayersGhostSpawning);
+        SubscribeLocalEvent<WizardComponent, MindAddedMessage>(OnMindAdded);
+        SubscribeLocalEvent<WizardComponent, ComponentInit>(OnComponentInit);
+        SubscribeLocalEvent<WizardComponent, ComponentRemove>(OnComponentRemove);
+    }
+
+    private void OnComponentInit(EntityUid uid, WizardComponent component, ComponentInit args)
+    {
+        // If entity has a prior mind attached, add them to the players list.
+        if (!TryComp<MindComponent>(uid, out var mindComponent) || !RuleAdded)
+            return;
+
+        var session = mindComponent.Mind?.Session;
+        var name = MetaData(uid).EntityName;
+        if (session != null)
+            _wizardPlayers.Add(name, session);
+    }
+
+    private void OnComponentRemove(EntityUid uid, WizardComponent component, ComponentRemove args)
+    {
+        CheckRoundShouldEnd();
+    }
+
+    private void OnRunLevelChanged(GameRunLevelChangedEvent ev)
+    {
+        switch (ev.New)
+        {
+            case GameRunLevel.InRound:
+                OnRoundStart();
+                break;
+            case GameRunLevel.PostRound:
+                OnRoundEnd();
+                break;
+        }
+    }
+
+    private void OnRoundStart()
+    {
+        // TODO: This needs to try and target a Nanotrasen station. At the very least,
+        // we can only currently guarantee that NT stations are the only station to
+        // exist in the base game.
+
+        _targetStation = _stationSystem.Stations.FirstOrNull();
+    }
+
+    private void OnRoundEnd()
+    {
+        _targetStation = null;
+    }
+
+    private void OnRoundEndText(RoundEndTextAppendEvent ev)
+    {
+        if (!RuleAdded)
+            return;
+
+        var winText = Loc.GetString($"wizard-rule-endtext");
+
+        ev.AddLine(winText);
+
+        ev.AddLine(Loc.GetString("wizard-list-start"));
+        foreach (var (name, session) in _wizardPlayers)
+        {
+            var listing = Loc.GetString("wizard-list-name", ("name", name), ("user", session.Name));
+            ev.AddLine(listing);
+        }
+    }
+
+    private void CheckRoundShouldEnd()
+    {
+        if (!RuleAdded || !_wizardRuleConfig.EndsRound)
+            return;
+
+        MapId? shuttleMapId = EntityManager.EntityExists(_wizardShuttle)
+            ? Transform(_wizardShuttle!.Value).MapID
+            : null;
+
+        MapId? targetStationMap = null;
+        if (_targetStation != null && TryComp(_targetStation, out StationDataComponent? data))
+        {
+            var grid = data.Grids.FirstOrNull();
+            targetStationMap = grid != null
+                ? Transform(grid.Value).MapID
+                : null;
+        }
+
+        // Check if there are wizards still alive on the same map as the shuttle,
+        // or on the same map as the station.
+        // If there are, the round can continue.
+        var wizards = EntityQuery<WizardComponent, MobStateComponent, TransformComponent>(true);
+        var wizardsAlive = wizards
+            .Where(ent =>
+                ent.Item3.MapID == shuttleMapId
+                || ent.Item3.MapID == targetStationMap)
+            .Any(ent => ent.Item2.CurrentState == MobState.Alive && ent.Item1.Running);
+
+        if (wizardsAlive)
+            return; // There are living wizards can access the shuttle, or are still on the station's map.
+
+        // Check that there are spawns available and that they can access the shuttle.
+        var spawnsAvailable = EntityQuery<WizardSpawnerComponent>(true).Any();
+        if (spawnsAvailable && shuttleMapId == _wizardMap)
+            return; // Ghost spawns can still access the shuttle. Continue the round.
+
+        RuleWinType = WinType.WizardsEliminated;
+    }
+
+    private void OnMobStateChanged(EntityUid uid, WizardComponent component, MobStateChangedEvent ev)
+    {
+        if(ev.NewMobState == MobState.Dead)
+            CheckRoundShouldEnd();
+    }
+
+    private void OnPlayersSpawning(RulePlayerSpawningEvent ev)
+    {
+        if (!RuleAdded)
+            return;
+
+        // Basically copied verbatim from traitor code
+        var playersPerWizard = _wizardRuleConfig.PlayersPerWizard;
+        var maxWizards = _wizardRuleConfig.MaxWizards;
+
+        var everyone = new List<IPlayerSession>(ev.PlayerPool);
+        var prefList = new List<IPlayerSession>();
+        var wizards = new List<IPlayerSession>();
+
+        // The LINQ expression ReSharper keeps suggesting is completely unintelligible so I'm disabling it
+        // ReSharper disable once ForeachCanBeConvertedToQueryUsingAnotherGetEnumerator
+        foreach (var player in everyone)
+        {
+            if (!ev.Profiles.ContainsKey(player.UserId))
+            {
+                continue;
+            }
+            var profile = ev.Profiles[player.UserId];
+            if (profile.AntagPreferences.Contains(_wizardRuleConfig.WizardRoleProto))
+            {
+                prefList.Add(player);
+            }
+        }
+
+        var numWizards = MathHelper.Clamp(ev.PlayerPool.Count / playersPerWizard, 1, maxWizards);
+
+        for (var i = 0; i < numWizards; i++)
+        {
+            IPlayerSession wizard;
+
+            if (prefList.Count == 0)
+            {
+                if (everyone.Count == 0)
+                {
+                    Logger.InfoS("preset", "Insufficient ready players to spawn wizards, stopping the selection");
+                    break;
+                }
+                wizard = _random.PickAndTake(everyone);
+                Logger.InfoS("preset", "Insufficient preferred wizards, picking at random.");
+            }
+            else
+            {
+                wizard = _random.PickAndTake(prefList);
+                everyone.Remove(wizard);
+                Logger.InfoS("preset", "Selected a preferred wizard.");
+            }
+
+            wizards.Add(wizard);
+        }
+
+        SpawnWizards(numWizards, wizards, false);
+
+        foreach(var session in wizards)
+        {
+            ev.PlayerPool.Remove(session);
+            GameTicker.PlayerJoinGame(session);
+            var name = session.AttachedEntity == null
+                ? string.Empty
+                : MetaData(session.AttachedEntity.Value).EntityName;
+            // TODO: Fix this being able to have duplicates
+            _wizardPlayers[name] = session;
+        }
+    }
+
+    private void OnPlayersGhostSpawning(EntityUid uid, WizardComponent component, GhostRoleSpawnerUsedEvent args)
+    {
+        var spawner = args.Spawner;
+
+        if (!TryComp<WizardSpawnerComponent>(spawner, out var wizardSpawner))
+            return;
+
+        HumanoidCharacterProfile? profile = null;
+        if (TryComp(args.Spawned, out ActorComponent? actor))
+            profile = _prefs.GetPreferences(actor.PlayerSession.UserId).SelectedCharacter as HumanoidCharacterProfile;
+
+        SetupWizardEntity(uid, wizardSpawner.WizardName, wizardSpawner.WizardStartingGear, profile);
+
+        _wizardMindPendingData.Add(uid, wizardSpawner.WizardRolePrototype);
+    }
+
+    private void OnMindAdded(EntityUid uid, WizardComponent component, MindAddedMessage args)
+    {
+        if (!TryComp<MindComponent>(uid, out var mindComponent) || mindComponent.Mind == null)
+            return;
+
+        var mind = mindComponent.Mind;
+
+        if (_wizardMindPendingData.TryGetValue(uid, out var role))
+        {
+            mind.AddRole(new TraitorRole(mind, _prototypeManager.Index<AntagPrototype>(role)));
+            _wizardMindPendingData.Remove(uid);
+        }
+
+        if (!mind.TryGetSession(out var playerSession))
+            return;
+        if (_wizardPlayers.ContainsValue(playerSession))
+            return;
+
+        var name = MetaData(uid).EntityName;
+
+        _wizardPlayers.Add(name, playerSession);
+
+        if (_ticker.RunLevel != GameRunLevel.InRound)
+            return;
+
+        if (_targetStation != null && !string.IsNullOrEmpty(Name(_targetStation.Value)))
+            _chatManager.DispatchServerMessage(playerSession, Loc.GetString("wizards-welcome", ("station", _targetStation.Value)));
+    }
+
+    private bool SpawnMap()
+    {
+        if (_wizardMap != null)
+            return true; // Map is already loaded.
+
+        var shuttlePath = _wizardRuleConfig.WizardShuttleMap;
+
+        if (shuttlePath == null)
+        {
+            Logger.ErrorS("wizards", "No shuttle map specified for wizards!");
+            return false;
+        }
+
+        var mapId = _mapManager.CreateMap();
+
+        if (!_map.TryLoad(mapId, shuttlePath.ToString(), out var grids, new MapLoadOptions {Offset = Vector2.One*1000f}) || !grids.Any())
+        {
+            Logger.ErrorS("wizards", $"Error loading grid {shuttlePath} for wizards!");
+            return false;
+        }
+
+        var shuttleId = grids[0];
+
+        // Naughty, someone saved the shuttle as a map.
+        if (Deleted(shuttleId))
+        {
+            Logger.ErrorS("wizards", $"Tried to load wizard shuttle as a map, aborting.");
+            _mapManager.DeleteMap(mapId);
+            return false;
+        }
+
+        _wizardMap = mapId;
+        _wizardShuttle = shuttleId;
+
+        return true;
+    }
+
+    private (string Name, string Role, string Gear) GetWizardSpawnDetails(int spawnNumber)
+    {
+        string name;
+        string role;
+        string gear;
+
+        switch (spawnNumber)
+        {
+            default:
+                name = _random.PickAndTake(_wizardNames[_wizardRuleConfig.WizardFirstNames]) +
+                    " " +
+                    _random.PickAndTake(_wizardNames[_wizardRuleConfig.WizardLastNames]);
+
+                role = _wizardRuleConfig.WizardRoleProto;
+                gear = _wizardRuleConfig.WizardStartGearPrototype;
+                break;
+        }
+
+        return (name, role, gear);
+    }
+
+    /// <summary>
+    ///     Adds missing nuke operative components, equips starting gear and renames the entity.
+    /// </summary>
+    private void SetupWizardEntity(EntityUid mob, string name, string gear, HumanoidCharacterProfile? profile)
+    {
+        MetaData(mob).EntityName = name;
+        EntityManager.EnsureComponent<RandomHumanoidAppearanceComponent>(mob);
+        EntityManager.EnsureComponent<WizardComponent>(mob);
+
+        if(_startingGearPrototypes.TryGetValue(gear, out var gearPrototype))
+            _stationSpawningSystem.EquipStartingGear(mob, gearPrototype, profile);
+
+        _faction.RemoveFaction(mob, "NanoTrasen", false);
+        _faction.AddFaction(mob, "Syndicate");
+    }
+
+    private void SpawnWizards(int spawnCount, List<IPlayerSession> sessions, bool addSpawnPoints)
+    {
+        if (_wizardShuttle == null)
+            return;
+
+        var spawns = new List<EntityCoordinates>();
+
+        foreach (var (_, meta, xform) in EntityManager.EntityQuery<SpawnPointComponent, MetaDataComponent, TransformComponent>(true))
+        {
+            if (meta.EntityPrototype?.ID != _wizardRuleConfig.SpawnPointPrototype)
+                continue;
+
+            if (xform.ParentUid != _wizardShuttle)
+                continue;
+
+            spawns.Add(xform.Coordinates);
+            break;
+        }
+
+        if (spawns.Count == 0)
+        {
+            spawns.Add(EntityManager.GetComponent<TransformComponent>((EntityUid) _wizardShuttle).Coordinates);
+            Logger.WarningS("wizards", $"Fell back to default spawn for wizards!");
+        }
+
+        // TODO: This should spawn the nukies in regardless and transfer if possible; rest should go to shot roles.
+        for(var i = 0; i < spawnCount; i++)
+        {
+            var spawnDetails = GetWizardSpawnDetails(i);
+            var wizardAntag = _prototypeManager.Index<AntagPrototype>(spawnDetails.Role);
+
+            if (sessions.TryGetValue(i, out var session))
+            {
+                var mob = _randomHumanoid.SpawnRandomHumanoid(_wizardRuleConfig.RandomHumanoidSettingsPrototype, _random.Pick(spawns), string.Empty);
+                var profile = _prefs.GetPreferences(session.UserId).SelectedCharacter as HumanoidCharacterProfile;
+                SetupWizardEntity(mob, spawnDetails.Name, spawnDetails.Gear, profile);
+
+                var newMind = new Mind.Mind(session.UserId)
+                {
+                    CharacterName = spawnDetails.Name
+                };
+                newMind.ChangeOwningPlayer(session.UserId);
+                newMind.AddRole(new TraitorRole(newMind, wizardAntag));
+
+                newMind.TransferTo(mob);
+            }
+            else if (addSpawnPoints)
+            {
+                var spawnPoint = EntityManager.SpawnEntity(_wizardRuleConfig.GhostSpawnPointProto, _random.Pick(spawns));
+                var spawner = EnsureComp<GhostRoleMobSpawnerComponent>(spawnPoint);
+                spawner.RoleName = Loc.GetString(wizardAntag.Name);
+                spawner.RoleDescription = Loc.GetString(wizardAntag.Objective);
+
+                var wizardSpawner = EnsureComp<WizardSpawnerComponent>(spawnPoint);
+                wizardSpawner.WizardName = spawnDetails.Name;
+                wizardSpawner.WizardRolePrototype = spawnDetails.Role;
+                wizardSpawner.WizardStartingGear = spawnDetails.Gear;
+            }
+        }
+    }
+
+    private void SpawnWizardsForGhostRoles()
+    {
+        // Basically copied verbatim from traitor code
+        var playersPerOperative = _wizardRuleConfig.PlayersPerWizard;
+        var maxOperatives = _wizardRuleConfig.MaxWizards;
+
+        var playerPool = _playerSystem.ServerSessions.ToList();
+        var numNukies = MathHelper.Clamp(playerPool.Count / playersPerOperative, 1, maxOperatives);
+
+        var operatives = new List<IPlayerSession>();
+        SpawnWizards(numNukies, operatives, true);
+    }
+
+    //For admins forcing someone to wizard.
+    public void MakeLoneWizard(Mind.Mind mind)
+    {
+        if (!mind.OwnedEntity.HasValue)
+            return;
+
+        mind.AddRole(new TraitorRole(mind, _prototypeManager.Index<AntagPrototype>(_wizardRuleConfig.WizardRoleProto)));
+        SetOutfitCommand.SetOutfit(mind.OwnedEntity.Value, "WizardGearFull", EntityManager);
+    }
+
+    private void OnStartAttempt(RoundStartAttemptEvent ev)
+    {
+        if (!RuleAdded || Configuration is not WizardRuleConfiguration wizardConfig)
+            return;
+
+        _wizardRuleConfig = wizardConfig;
+        var minPlayers = wizardConfig.MinPlayers;
+        if (!ev.Forced && ev.Players.Length < minPlayers)
+        {
+            _chatManager.DispatchServerAnnouncement(Loc.GetString("wizard-not-enough-ready-players", ("readyPlayersCount", ev.Players.Length), ("minimumPlayers", minPlayers)));
+            ev.Cancel();
+            return;
+        }
+
+        if (ev.Players.Length != 0)
+            return;
+
+        _chatManager.DispatchServerAnnouncement(Loc.GetString("wizards-no-one-ready"));
+        ev.Cancel();
+    }
+
+    public override void Started()
+    {
+        RuleWinType = WinType.Neutral;
+//        _winConditions.Clear();
+        _wizardMap = null;
+
+        _startingGearPrototypes.Clear();
+        _wizardNames.Clear();
+        _wizardMindPendingData.Clear();
+        _wizardPlayers.Clear();
+
+        var proto = _wizardRuleConfig.WizardStartGearPrototype;
+        _startingGearPrototypes.Add(proto, _prototypeManager.Index<StartingGearPrototype>(proto));
+
+        foreach (var name in new[] { _wizardRuleConfig.WizardFirstNames, _wizardRuleConfig.WizardLastNames })
+        {
+            _wizardNames.Add(name, new List<string>(_prototypeManager.Index<DatasetPrototype>(name).Values));
+        }
+
+        if (!SpawnMap())
+        {
+            Logger.InfoS("wizards", "Failed to load map for wizards");
+            return;
+        }
+
+        // Add pre-existing wizards to the credit list.
+        var query = EntityQuery<WizardComponent, MindComponent>(true);
+        foreach (var (_, mindComp) in query)
+        {
+            if (mindComp.Mind == null || !mindComp.Mind.TryGetSession(out var session))
+                continue;
+            var name = MetaData(mindComp.Owner).EntityName;
+            _wizardPlayers.Add(name, session);
+        }
+
+        if (GameTicker.RunLevel == GameRunLevel.InRound)
+            SpawnWizardsForGhostRoles();
+    }
+
+    public override void Ended() { }
+}

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-wizards.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-wizards.ftl
@@ -3,8 +3,8 @@ wizard-description = The Space Wizard Federation has sent a representative to th
 
 wizard-welcome = You are a Wizard sent by the Space Wizard Federation to make the station a more magical place. Bring chaos to the station and try to make it back alive!
 
-wizard-eliminated = [color=green]Wizards Eliminated![/color]
-wizard-escaped = [color=crimson]The Wizards Escaped![/color]
+wizard-eliminated = [color=green]The Wizards were eliminated![/color]
+wizard-escaped = [color=crimson]The Wizards escaped![/color]
 
 wizard-list-start = The Wizards were:
 wizard-list-name = - [color=White]{$name}[/color] ([color=gray]{$user}[/color])

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-wizards.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-wizards.ftl
@@ -1,0 +1,12 @@
+﻿wizard-title = Wizards
+wizard-description = The Space Wizard Federation has sent a representative to the station.
+
+wizard-welcome = You are a Wizard sent by the Space Wizard Federation to make the station a more magical place. Bring chaos to the station and try to make it back alive!
+
+wizard-eliminated = [color=green]Wizards Eliminated![/color]
+wizard-escaped = [color=crimson]The Wizards Escaped![/color]
+
+wizard-list-start = The Wizards were:
+wizard-list-name = - [color=White]{$name}[/color] ([color=gray]{$user}[/color])
+wizard-not-enough-ready-players = Not enough players readied up for the game! There were {$readyPlayersCount} players readied up out of {$minimumPlayers} needed. Can't start Wizards.
+wizard-no-one-ready = No players readied up! Can't start Wizards.

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-wizards.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-wizards.ftl
@@ -10,3 +10,6 @@ wizard-list-start = The Wizards were:
 wizard-list-name = - [color=White]{$name}[/color] ([color=gray]{$user}[/color])
 wizard-not-enough-ready-players = Not enough players readied up for the game! There were {$readyPlayersCount} players readied up out of {$minimumPlayers} needed. Can't start Wizards.
 wizard-no-one-ready = No players readied up! Can't start Wizards.
+
+roles-antag-wizard-name = Wizard
+roles-antag-wizard-objective = Make the station a magical place and survive the ensuing chaos.

--- a/Resources/Locale/en-US/store/categories.ftl
+++ b/Resources/Locale/en-US/store/categories.ftl
@@ -15,3 +15,8 @@ store-category-pointless = Pointless
 
 # Revenant
 store-category-abilities = Abilities
+
+# Wizards
+store-category-books = Books
+store-category-staves = Staves
+store-category-wands = Wands

--- a/Resources/Locale/en-US/store/currency.ftl
+++ b/Resources/Locale/en-US/store/currency.ftl
@@ -5,5 +5,6 @@ store-currency-display-debugdollar = {$amount ->
     [one] Debug Dollar
     *[other] Debug Dollars
 }
+store-currency-display-spell-points = SP
 store-currency-display-telecrystal = TC
 store-currency-display-stolen-essence = Stolen Essence

--- a/Resources/Locale/en-US/store/spellbook-catalog.ftl
+++ b/Resources/Locale/en-US/store/spellbook-catalog.ftl
@@ -1,0 +1,37 @@
+# Books
+
+spellbook-scroll-runes-name = Scroll of Runes
+spellbook-scroll-runes-description = A variety of incantations placed on the ground.
+
+# Staves
+
+spellbook-entrance-staff-name = Entrance
+spellbook-entrance-staff-description = Interior decorating in the palm of your hand.
+
+spellbook-healing-staff-name = Healing
+spellbook-healing-staff-Description = From the Space Wizard Federation's xxx.
+
+spellbook-rgb-staff-name = RGB
+spellbook-rgb-staff-description = Its gaming time.
+
+# Wands
+
+spellbook-poly-monkey-wand-name = Monkey Polymorph
+spellbook-poly-monkey-wand-description = For when you really need a friend. 5 charges.
+
+spellbook-death-wand-name = Instant Death
+spellbook-death-wand-description = From the brightest minds at the Space Wizard Federation. 3 charges.
+
+spellbook-entrance-wand-description = Interior decorating in the palm of your hand. x charges.
+
+spellbook-poly-carp-wand-description = Turn your enemies into different enemies. x charges.
+
+spellbook-fireball-wand-description = EL' NATH! x charges.
+
+# Misc
+
+spellbook-hardsuit-name = Wizard Hardsuit
+spellbook-hardsuit-description = A Bizarre gem-encrusted suit that radiates magical energies.
+
+spellbook-wand-belt-name = Wand Belt
+spellbook-wand-belt-description = A belt designed to hold various rods of power. A veritable fanny pack of exotic magic. Wands not included.

--- a/Resources/Locale/en-US/store/spellbook-catalog.ftl
+++ b/Resources/Locale/en-US/store/spellbook-catalog.ftl
@@ -9,7 +9,7 @@ spellbook-entrance-staff-name = Entrance
 spellbook-entrance-staff-description = Interior decorating in the palm of your hand.
 
 spellbook-healing-staff-name = Healing
-spellbook-healing-staff-Description = From the Space Wizard Federation's xxx.
+spellbook-healing-staff-description = The Space Wizard Federation is still trying to find a use for this mysterious power.
 
 spellbook-rgb-staff-name = RGB
 spellbook-rgb-staff-description = Its gaming time.
@@ -22,11 +22,13 @@ spellbook-poly-monkey-wand-description = For when you really need a friend. 5 ch
 spellbook-death-wand-name = Instant Death
 spellbook-death-wand-description = From the brightest minds at the Space Wizard Federation. 3 charges.
 
-spellbook-entrance-wand-description = Interior decorating in the palm of your hand. x charges.
+spellbook-entrance-wand-description = Interior decorating in the palm of your hand. 10 charges.
 
-spellbook-poly-carp-wand-description = Turn your enemies into different enemies. x charges.
+spellbook-poly-carp-wand-name = Magicarp Polymorph
+spellbook-poly-carp-wand-description = Turn your enemies into different enemies. 5 charges.
 
-spellbook-fireball-wand-description = EL' NATH! x charges.
+spellbook-fireball-wand-description = Fireball
+spellbook-fireball-wand-description = ONI'SOMA! Beware tight spaces. 5 charges.
 
 # Misc
 

--- a/Resources/Prototypes/Catalog/spellbook_catalog.yml
+++ b/Resources/Prototypes/Catalog/spellbook_catalog.yml
@@ -100,7 +100,7 @@
 
 - type: listing
   id: SpellbookPolyCarpWand
-  name: action-name-spell-summon-magicarp
+  name: spellbook-poly-carp-wand-name
   description: spellbook-poly-carp-wand-description
   productEntity: WeaponWandPolymorphCarp
   cost:

--- a/Resources/Prototypes/Catalog/spellbook_catalog.yml
+++ b/Resources/Prototypes/Catalog/spellbook_catalog.yml
@@ -1,0 +1,181 @@
+- type: listing
+  id: SpellbookSpawnBook
+  name: spellbook-spawn-book-name
+  description: spellbook-spawn-book-description
+  productEntity: SpawnSpellbook
+  cost:
+    Spellpoint: 2
+  categories:
+  - SpellbookBooks
+
+- type: listing
+  id: SpellbookForceWallBook
+  name: spellbook-force-wall-book-name
+  description: spellbook-force-wall-book-description
+  productEntity: ForceWallSpellbook
+  cost:
+    Spellpoint: 2
+  categories:
+  - SpellbookBooks
+
+- type: listing
+  id: SpellbookBlinkBook
+  name: spellbook-blink-book-name
+  description: spellbook-blink-book-description
+  productEntity: BlinkBook
+  cost:
+    Spellpoint: 2
+  categories:
+  - SpellbookBooks
+
+- type: listing
+  id: SpellbookSmiteBook
+  name: spellbook-smite-book-name
+  description: spellbook-smite-book-description
+  productEntity: SmiteBook
+  cost:
+    Spellpoint: 4
+  categories:
+  - SpellbookBooks
+  
+- type: listing
+  id: SpellbookKnockSpellbook
+  name: spellbook-knock-book-name
+  description: spellbook-knock-book-description
+  productEntity: KnockSpellbook
+  cost:
+    Spellpoint: 2
+  categories:
+  - SpellbookBooks
+  
+- type: listing
+  id: SpellbookFireballSpellbook
+  name: spellbook-fireball-book-name
+  description: spellbook-fireball-book-description
+  productEntity: FireballSpellbook
+  cost:
+    Spellpoint: 5
+  categories:
+  - SpellbookBooks
+
+- type: listing
+  id: SpellbookScrollRunes
+  name: spellbook-scroll-runes-name
+  description: spellbook-scroll-runes-description
+  productEntity: ScrollRunes
+  cost:
+    Spellpoint: 2
+  categories:
+  - SpellbookBooks
+
+- type: listing
+  id: SpellbookEntranceStaff
+  name: spellbook-entrance-staff-name
+  description: spellbook-entrance-staff-description
+  productEntity: WeaponStaffPolymorphDoor
+  cost:
+    Spellpoint: 2
+  categories:
+  - SpellbookStaves
+
+- type: listing
+  id: SpellbookHealingStaff
+  name: spellbook-healing-staff-name
+  description: spellbook-healing-staff-description
+  productEntity: WeaponStaffHealing
+  cost:
+    Spellpoint: 2
+  categories:
+  - SpellbookStaves
+
+- type: listing
+  id: SpellbookRGBStaff
+  name: spellbook-rgb-staff-name
+  description: spellbook-rgb-staff-description
+  productEntity: RGBStaff
+  cost:
+    Spellpoint: 1
+  categories:
+  - SpellbookStaves
+
+- type: listing
+  id: SpellbookPolyCarpWand
+  name: spellbook-poly-carp-wand-name
+  description: spellbook-poly-carp-wand-description
+  productEntity: WeaponWandPolymorphCarp
+  cost:
+    Spellpoint: 2
+  categories:
+  - SpellbookWands
+
+- type: listing
+  id: SpellbookPolyMonkeyWand
+  name: spellbook-poly-monkey-wand-name
+  description: spellbook-poly-monkey-wand-description
+  productEntity: WeaponWandPolymorphMonkey
+  cost:
+    Spellpoint: 2
+  categories:
+  - SpellbookWands
+
+- type: listing
+  id: SpellbookFireballWand
+  name: spellbook-fireball-wand-name
+  description: spellbook-fireball-wand-description
+  productEntity: WeaponWandFireball
+  cost:
+    Spellpoint: 3
+  categories:
+  - SpellbookWands
+
+- type: listing
+  id: SpellbookDeathWand
+  name: spellbook-death-wand-name
+  description: spellbook-death-wand-description
+  productEntity: WeaponWandDeath
+  cost:
+    Spellpoint: 3
+  categories:
+  - SpellbookWands
+
+- type: listing
+  id: SpellbookEntranceWand
+  name: spellbook-entrance-wand-name
+  description: spellbook-entrance-wand-description
+  productEntity: WeaponWandPolymorphDoor
+  cost:
+    Spellpoint: 1
+  categories:
+  - SpellbookWands
+
+- type: listing
+  id: SpellbookWandBelt
+  name: spellbook-wand-belt-name
+  description: spellbook-wand-belt-description
+  productEntity: ClothingBeltWand
+  cost:
+    Spellpoint: 1
+  categories:
+  - SpellbookMisc
+
+- type: listing
+  id: SpellbookWizardHardsuit
+  name: spellbook-hardsuit-name
+  description: spellbook-hardsuit-description
+  productEntity: ClothingOuterHardsuitWizard
+  cost:
+    Spellpoint: 1
+  categories:
+  - SpellbookMisc
+
+- type: listing
+  id: SpellbookHoloparaKit
+  name: uplink-holopara-kit-name
+  description: uplink-holopara-kit-desc
+  icon: { sprite: /Textures/Objects/Misc/guardian_info.rsi, state: icon }
+  productEntity: BoxHoloparasite
+  cost:
+    Spellpoint: 3
+  categories:
+  - SpellbookMisc
+  

--- a/Resources/Prototypes/Catalog/spellbook_catalog.yml
+++ b/Resources/Prototypes/Catalog/spellbook_catalog.yml
@@ -1,27 +1,27 @@
 - type: listing
   id: SpellbookSpawnBook
-  name: spellbook-spawn-book-name
-  description: spellbook-spawn-book-description
+  name: action-name-spell-summon-magicarp
+  description: action-description-spell-summon-magicarp
   productEntity: SpawnSpellbook
   cost:
-    Spellpoint: 2
+    Spellpoint: 3
   categories:
   - SpellbookBooks
 
 - type: listing
   id: SpellbookForceWallBook
-  name: spellbook-force-wall-book-name
-  description: spellbook-force-wall-book-description
+  name: action-name-spell-forcewall
+  description: action-description-spell-forcewall
   productEntity: ForceWallSpellbook
   cost:
-    Spellpoint: 2
+    Spellpoint: 3
   categories:
   - SpellbookBooks
 
 - type: listing
   id: SpellbookBlinkBook
-  name: spellbook-blink-book-name
-  description: spellbook-blink-book-description
+  name: action-name-spell-blink
+  description: action-description-spell-blink
   productEntity: BlinkBook
   cost:
     Spellpoint: 2
@@ -30,18 +30,18 @@
 
 - type: listing
   id: SpellbookSmiteBook
-  name: spellbook-smite-book-name
-  description: spellbook-smite-book-description
+  name: action-name-spell-smite
+  description: action-description-spell-smite
   productEntity: SmiteBook
   cost:
-    Spellpoint: 4
+    Spellpoint: 5
   categories:
   - SpellbookBooks
   
 - type: listing
   id: SpellbookKnockSpellbook
-  name: spellbook-knock-book-name
-  description: spellbook-knock-book-description
+  name: action-name-spell-knock
+  description: action-description-spell-knock
   productEntity: KnockSpellbook
   cost:
     Spellpoint: 2
@@ -50,8 +50,8 @@
   
 - type: listing
   id: SpellbookFireballSpellbook
-  name: spellbook-fireball-book-name
-  description: spellbook-fireball-book-description
+  name: action-name-spell-fireball
+  description: action-description-spell-fireball
   productEntity: FireballSpellbook
   cost:
     Spellpoint: 5
@@ -64,7 +64,7 @@
   description: spellbook-scroll-runes-description
   productEntity: ScrollRunes
   cost:
-    Spellpoint: 2
+    Spellpoint: 3
   categories:
   - SpellbookBooks
 
@@ -74,7 +74,7 @@
   description: spellbook-entrance-staff-description
   productEntity: WeaponStaffPolymorphDoor
   cost:
-    Spellpoint: 2
+    Spellpoint: 1
   categories:
   - SpellbookStaves
 
@@ -84,7 +84,7 @@
   description: spellbook-healing-staff-description
   productEntity: WeaponStaffHealing
   cost:
-    Spellpoint: 2
+    Spellpoint: 1
   categories:
   - SpellbookStaves
 
@@ -100,11 +100,11 @@
 
 - type: listing
   id: SpellbookPolyCarpWand
-  name: spellbook-poly-carp-wand-name
+  name: action-name-spell-summon-magicarp
   description: spellbook-poly-carp-wand-description
   productEntity: WeaponWandPolymorphCarp
   cost:
-    Spellpoint: 2
+    Spellpoint: 1
   categories:
   - SpellbookWands
 
@@ -114,7 +114,7 @@
   description: spellbook-poly-monkey-wand-description
   productEntity: WeaponWandPolymorphMonkey
   cost:
-    Spellpoint: 2
+    Spellpoint: 1
   categories:
   - SpellbookWands
 
@@ -124,7 +124,7 @@
   description: spellbook-fireball-wand-description
   productEntity: WeaponWandFireball
   cost:
-    Spellpoint: 3
+    Spellpoint: 2
   categories:
   - SpellbookWands
 
@@ -134,13 +134,13 @@
   description: spellbook-death-wand-description
   productEntity: WeaponWandDeath
   cost:
-    Spellpoint: 3
+    Spellpoint: 1
   categories:
   - SpellbookWands
 
 - type: listing
   id: SpellbookEntranceWand
-  name: spellbook-entrance-wand-name
+  name: spellbook-entrance-staff-name
   description: spellbook-entrance-wand-description
   productEntity: WeaponWandPolymorphDoor
   cost:

--- a/Resources/Prototypes/Entities/Markers/Spawners/Conditional/wizards.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Conditional/wizards.yml
@@ -7,5 +7,5 @@
   - type: Sprite
     layers:
     - state: green
-    - sprite: Objects/Fun/toys.rsi
-      state: synb
+    - sprite: Clothing/Head/Hats/wizardhat.rsi
+      state: icon

--- a/Resources/Prototypes/Entities/Markers/Spawners/Conditional/wizards.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Conditional/wizards.yml
@@ -1,0 +1,11 @@
+- type: entity
+  id: SpawnPointWizard
+  parent: MarkerBase
+  name: wizard
+  components:
+  - type: SpawnPoint
+  - type: Sprite
+    layers:
+    - state: green
+    - sprite: Objects/Fun/toys.rsi
+      state: synb

--- a/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
@@ -70,4 +70,22 @@
       - sprite: Structures/Wallmounts/signs.rsi
         state: radiation
 
+- type: entity
+  noSpawn: true
+  id: SpawnPointGhostWizard
+  name: ghost role spawn point
+  suffix: wizard
+  parent: MarkerBase
+  components:
+  - type: GhostRoleMobSpawner
+    prototype: MobHumanWizard
+    rules: You are a wizard tasked with making the station a more magical place. As an antagonist, do whatever is required to complete this task.
+  - type: WizardSpawner
+  - type: Sprite
+    sprite: Markers/jobs.rsi
+    layers:
+      - state: green
+      - sprite: Structures/Wallmounts/signs.rsi
+        state: radiation
+
 

--- a/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
@@ -85,7 +85,7 @@
     sprite: Markers/jobs.rsi
     layers:
       - state: green
-      - sprite: Structures/Wallmounts/signs.rsi
-        state: radiation
+      - sprite: Clothing/Head/Hats/wizardhat.rsi
+        state: icon
 
 

--- a/Resources/Prototypes/Entities/Mobs/Player/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/human.yml
@@ -58,3 +58,12 @@
   components:
     - type: NukeOperative
     - type: RandomHumanoidAppearance
+    
+- type: entity
+  noSpawn: true
+  name: Wizard
+  parent: MobHuman
+  id: MobHumanWizard
+  components:
+    - type: Wizard
+    - type: RandomHumanoidAppearance

--- a/Resources/Prototypes/Entities/Mobs/Player/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/human.yml
@@ -58,7 +58,8 @@
   components:
     - type: NukeOperative
     - type: RandomHumanoidAppearance
-    
+
+# Wizards    
 - type: entity
   noSpawn: true
   name: Wizard

--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -383,3 +383,17 @@
       name: Cluwne
       description: Become a pitiful cluwne, your only goal in life is to find a sweet release from your suffering (usually by being beaten to death). A cluwne is not an antagonist but may defend itself. Crewmembers may murder cluwnes freely.
     - type: Cluwne
+  id: RandomHumanoidSpawnerWizard
+  name: Wizard
+  components:
+    - type: Sprite
+      netsync: false
+      sprite: Mobs/Species/Human/parts.rsi
+      state: full
+    - type: RandomHumanoidSpawner
+      settings: WizardHumanoid
+
+- type: randomHumanoidSettings
+  id: WizardHumanoid
+  components:
+    - type: Wizard

--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -392,8 +392,11 @@
       state: full
     - type: RandomHumanoidSpawner
       settings: WizardHumanoid
+    - type: Loadout
+      prototypes: [WizardBlueGear]
 
 - type: randomHumanoidSettings
   id: WizardHumanoid
   components:
     - type: Wizard
+

--- a/Resources/Prototypes/Entities/Objects/Specific/wizard.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/wizard.yml
@@ -31,13 +31,13 @@
   suffix: Empty
   components:
   - type: Sprite
-    sprite: Objects/Devices/communication.rsi
+    sprite: Objects/Misc/books.rsi
     layers:
-    - state: old-radio
+    - state: book1
     netsync: false
   - type: Item
-    sprite: Objects/Devices/communication.rsi
-    heldPrefix: old-radio
+    sprite: Objects/Misc/books.rsi
+    heldPrefix: book1
   - type: UserInterface
     interfaces:
     - key: enum.StoreUiKey.Key

--- a/Resources/Prototypes/Entities/Objects/Specific/wizard.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/wizard.yml
@@ -1,0 +1,60 @@
+# SpellBook
+- type: entity
+  name: spellpoints
+  parent: BaseItem
+  id: Spellpoints
+  suffix: 10 SP
+  description: It seems to be pulsing with magical energies.
+  components:
+  - type: Sprite
+    sprite: Objects/Specific/Syndicate/telecrystal.rsi
+    netsync: false
+    state: telecrystal
+  - type: Item
+    sprite: Objects/Specific/Syndicate/telecrystal.rsi
+  - type: Stack
+    count: 10
+    stackType: Telecrystal
+  - type: StaticPrice
+    price: 0
+  - type: StackPrice
+    price: 200
+  - type: Currency
+    price:
+      Spellpoints: 1
+
+- type: entity
+  parent: BaseItem
+  id: BaseSpellBookShop
+  name: spellbook
+  description: A dusty old tome...
+  suffix: Empty
+  components:
+  - type: Sprite
+    sprite: Objects/Devices/communication.rsi
+    layers:
+    - state: old-radio
+    netsync: false
+  - type: Item
+    sprite: Objects/Devices/communication.rsi
+    heldPrefix: old-radio
+  - type: UserInterface
+    interfaces:
+    - key: enum.StoreUiKey.Key
+      type: StoreBoundUserInterface
+  - type: ActivatableUI
+    key: enum.StoreUiKey.Key
+  - type: Store
+    preset: StorePresetSpellbook
+    balance:
+      Spellpoint: 0
+
+- type: entity
+  parent: BaseSpellBookShop
+  id: BaseSpellBook10SP
+  suffix: 10 SP
+  components:
+  - type: Store
+    preset: StorePresetSpellbook
+    balance:
+      Spellpoint: 10

--- a/Resources/Prototypes/Entities/Objects/Specific/wizard.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/wizard.yml
@@ -2,7 +2,7 @@
 - type: entity
   name: spellpoints
   parent: BaseItem
-  id: Spellpoints
+  id: Spellpoint
   suffix: 10 SP
   description: It seems to be pulsing with magical energies.
   components:
@@ -14,14 +14,14 @@
     sprite: Objects/Specific/Syndicate/telecrystal.rsi
   - type: Stack
     count: 10
-    stackType: Telecrystal
+    stackType: Spellpoint
   - type: StaticPrice
     price: 0
   - type: StackPrice
     price: 200
   - type: Currency
     price:
-      Spellpoints: 1
+      Spellpoint: 1
 
 - type: entity
   parent: BaseItem

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -31,6 +31,12 @@
     id: Pirates
 
 - type: gameRule
+  id: Wizard
+  config:
+    !type:WizardRuleConfiguration
+    id: Wizard
+    
+- type: gameRule
   id: Suspicion
   config:
     !type:GenericGameRuleConfiguration

--- a/Resources/Prototypes/Roles/Antags/wizard.yml
+++ b/Resources/Prototypes/Roles/Antags/wizard.yml
@@ -1,0 +1,6 @@
+- type: antag
+  id: Wizard
+  name: roles-antag-wizard-name
+  antagonist: true
+  setPreference: true
+  objective: roles-antag-wizard-objective

--- a/Resources/Prototypes/Roles/Jobs/Fun/wizard_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/wizard_startinggear.yml
@@ -9,6 +9,7 @@
     shoes: ClothingShoesWizard
     id: PassengerPDA
     ears: ClothingHeadsetService
+    pocket1: BaseSpellBook10SP
   innerclothingskirt: ClothingUniformJumpskirtColorDarkBlue
   satchel: ClothingBackpackSatchelFilled
   duffelbag: ClothingBackpackDuffelFilled

--- a/Resources/Prototypes/Stacks/Materials/crystals.yml
+++ b/Resources/Prototypes/Stacks/Materials/crystals.yml
@@ -3,3 +3,9 @@
   name: telecrystal
   icon: Objects/Specific/Syndicate/telecrystal.rsi
   spawn: Telecrystal1
+
+- type: stack
+  id: Spellpoint
+  name: spellpoint
+  icon: Objects/Specific/Syndicate/telecrystal.rsi
+  spawn: Spellpoint

--- a/Resources/Prototypes/Store/categories.yml
+++ b/Resources/Prototypes/Store/categories.yml
@@ -63,6 +63,27 @@
   name: store-category-pointless
   priority: 9
 
+#wizard
+- type: storeCategory
+  id: SpellbookBooks
+  name: store-category-books
+  priority: 0
+
+- type: storeCategory
+  id: SpellbookStaves
+  name: store-category-staves
+  priority: 1
+
+- type: storeCategory
+  id: SpellbookWands
+  name: store-category-wands
+  priority: 2
+
+- type: storeCategory
+  id: SpellbookMisc
+  name: store-category-misc
+  priority: 3
+
 #revenant
 - type: storeCategory
   id: RevenantAbilities

--- a/Resources/Prototypes/Store/currency.yml
+++ b/Resources/Prototypes/Store/currency.yml
@@ -10,6 +10,13 @@
   displayName: store-currency-display-stolen-essence
   canWithdraw: false
 
+- type: currency
+  id: Spellpoint
+  displayName: store-currency-display-spell-points
+  cash: 
+    1: Spellpoint
+  canWithdraw: false
+  
 #debug
 - type: currency
   id: DebugDollar

--- a/Resources/Prototypes/Store/presets.yml
+++ b/Resources/Prototypes/Store/presets.yml
@@ -15,3 +15,14 @@
   - UplinkPointless
   currencyWhitelist:
   - Telecrystal
+
+- type: storePreset
+  id: StorePresetSpellbook
+  storeName: Spellbook
+  categories:
+  - SpellbookBooks
+  - SpellbookStaves
+  - SpellbookWands
+  - SpellbookMisc
+  currencyWhitelist:
+  - Spellpoint

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -95,6 +95,19 @@
     - BasicStationEventScheduler
 
 - type: gamePreset
+  id: Wizard
+  alias:
+    - wizard
+    - wizards
+    - wiznerds
+  name: wizard-title
+  description: wizard-description
+  showInVote: false
+  rules:
+    - Wizard
+    - RampingStationEventScheduler
+    
+- type: gamePreset
   id: Zombie
   alias:
     - zombie


### PR DESCRIPTION
More progress towards implementing wizards for realsies. This does not add the wizard to the secret game mode pool, but it is able to be added both before and mid-round. More spells/more balance/more testing should probably be done before it's set to be automated at round start/mid-round.

Checklist:
[x] Add game rule and game config preset
[x] Add entity content for spawners and ghost role spawners
[ ] Add the spawners to the wizard shuttle (in a new PR, it works and tests fine without it but the spawn location isn't precise and I want to make some other changes to the shuttle at the same time)
[x] Add a spellbook using the store system and catalog existing wizard items
[x] Balance the spellbook offerings (I gave them fairly arbitrary spell point costs, mostly in line with /tg/)
- wands are limited charges so cheaper, staves are pretty pointless with their spells so they are also cheap, and books are just on cooldown so they are a bit more expensive. That's the extent of my balance reasoning.
[x] Add/Assign custom sprites for the spellbook, spell points, and spawner icons
[x] Finish localization for literally everything
[x] Discuss objectives and win conditions. Some places ended the round when the wizard dies but I have it implemented as optional, and with the station defaulting to the ramping event scheduler instead (basically like zombies). Even though a wizard may be defeated, their loot is often still the most dangerous and chaotic stuff and having it in the hands of the crew still fulfills the purpose of increasing the chaos on station so I have it set to not end the round, but its a simple boolean in the gameruleconfig to enable that behaviour if we want. Consensus seems to be that wizards only have abstract, fanciful objectives with no real success or failure states, so in the meantime I will look into the objectives system to see if I cant just write some silly abstract texts for objectives